### PR TITLE
#3 - update to latest JOSM API (13173+)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ You must be on JOSM v12712 or later for the latest build to work.
 Clone the project and edit the build.gradle to change the josm version to your JOSM's version:
 
 ```
-project.ext.josmVersion = '12712'
+project.ext.josmVersion = '13367'
 ```
 
 Then run:

--- a/build.gradle
+++ b/build.gradle
@@ -13,7 +13,7 @@ plugins {
 }
 
 project.ext.pluginName = 'josm-atlas'
-project.ext.josmVersion = '12712'
+project.ext.josmVersion = '13367'
 project.ext.josmMinVersion = '12712'
 
 apply from: 'dependencies.gradle'

--- a/src/main/java/org/openstreetmap/atlas/AtlasFileImporter.java
+++ b/src/main/java/org/openstreetmap/atlas/AtlasFileImporter.java
@@ -15,10 +15,10 @@ import org.openstreetmap.atlas.geography.atlas.AtlasResourceLoader;
 import org.openstreetmap.atlas.utilities.collections.Iterables;
 import org.openstreetmap.atlas.utilities.scalars.Duration;
 import org.openstreetmap.atlas.utilities.time.Time;
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.actions.ExtensionFileFilter;
 import org.openstreetmap.josm.data.Bounds;
 import org.openstreetmap.josm.data.osm.DataSet;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.io.importexport.FileImporter;
 import org.openstreetmap.josm.gui.progress.ProgressMonitor;
 import org.openstreetmap.josm.gui.util.GuiHelper;
@@ -74,14 +74,14 @@ public class AtlasFileImporter extends FileImporter
 
         GuiHelper.runInEDT(() ->
         {
-            Main.getLayerManager().addLayer(this.layer);
-            Main.getLayerManager().setActiveLayer(this.layer);
+            MainApplication.getLayerManager().addLayer(this.layer);
+            MainApplication.getLayerManager().setActiveLayer(this.layer);
             final JFrame parent = new JFrame();
             final String[] metaData = this.atlas.metaData().toString().split(",");
             JOptionPane.showMessageDialog(parent, metaData, "Atlas MetaData",
                     JOptionPane.INFORMATION_MESSAGE);
             final AtlasReaderDialog dialog = new AtlasReaderDialog(this.layer);
-            Main.map.addToggleDialog(dialog);
+            MainApplication.getMap().addToggleDialog(dialog);
         });
     }
 
@@ -111,10 +111,10 @@ public class AtlasFileImporter extends FileImporter
 
         GuiHelper.runInEDT(() ->
         {
-            Main.getLayerManager().addLayer(this.layer);
-            Main.getLayerManager().setActiveLayer(this.layer);
+            MainApplication.getLayerManager().addLayer(this.layer);
+            MainApplication.getLayerManager().setActiveLayer(this.layer);
             final AtlasReaderDialog dialog = new AtlasReaderDialog(this.layer);
-            Main.map.addToggleDialog(dialog);
+            MainApplication.getMap().addToggleDialog(dialog);
         });
     }
 

--- a/src/main/java/org/openstreetmap/atlas/AtlasReaderDialog.java
+++ b/src/main/java/org/openstreetmap/atlas/AtlasReaderDialog.java
@@ -43,7 +43,6 @@ import org.openstreetmap.atlas.geography.atlas.items.Line;
 import org.openstreetmap.atlas.geography.atlas.items.Point;
 import org.openstreetmap.atlas.geography.atlas.packed.PackedEdge;
 import org.openstreetmap.atlas.utilities.scalars.Distance;
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.data.coor.LatLon;
 import org.openstreetmap.josm.data.osm.Node;
 import org.openstreetmap.josm.data.osm.OsmPrimitive;
@@ -52,6 +51,7 @@ import org.openstreetmap.josm.data.osm.PrimitiveId;
 import org.openstreetmap.josm.data.osm.Relation;
 import org.openstreetmap.josm.data.osm.Way;
 import org.openstreetmap.josm.data.osm.visitor.BoundingXYVisitor;
+import org.openstreetmap.josm.gui.MainApplication;
 import org.openstreetmap.josm.gui.dialogs.DialogsPanel;
 import org.openstreetmap.josm.gui.dialogs.ToggleDialog;
 import org.openstreetmap.josm.gui.history.HistoryBrowserDialogManager;
@@ -282,7 +282,7 @@ public class AtlasReaderDialog extends ToggleDialog implements LayerChangeListen
             this.titleBar = new TitleBar(this.name, "world.png");
             this.titleBar.registerMouseListener();
             add(this.titleBar, BorderLayout.NORTH);
-            Main.getLayerManager().addLayerChangeListener(this);
+            MainApplication.getLayerManager().addLayerChangeListener(this);
         }
     }
 
@@ -354,9 +354,9 @@ public class AtlasReaderDialog extends ToggleDialog implements LayerChangeListen
 
                     // recreate list listeners with new list index (results of search)
                     createListListeners(searcher.getIndexToIdentifier());
-                    for (final MouseListener mouseListener : Main.map.mapView.getMouseListeners())
+                    for (final MouseListener mouseListener : MainApplication.getMap().mapView.getMouseListeners())
                     {
-                        Main.map.mapView.removeMouseListener(mouseListener);
+                        MainApplication.getMap().mapView.removeMouseListener(mouseListener);
                     }
                     createMapListener(searcher.getIndexToIdentifier());
                 }
@@ -459,7 +459,7 @@ public class AtlasReaderDialog extends ToggleDialog implements LayerChangeListen
      */
     private void createMapListener(final BiMap<Integer, PrimitiveId> indexToIdentifier)
     {
-        Main.map.mapView.addMouseListener(new MouseAdapter()
+        MainApplication.getMap().mapView.addMouseListener(new MouseAdapter()
         {
             @Override
             public void mouseClicked(final MouseEvent event)
@@ -469,7 +469,7 @@ public class AtlasReaderDialog extends ToggleDialog implements LayerChangeListen
                     previous.setHighlighted(false);
                 }
                 listClick = false;
-                final LatLon latlon = Main.map.mapView.getLatLon(event.getX(), event.getY());
+                final LatLon latlon = MainApplication.getMap().mapView.getLatLon(event.getX(), event.getY());
                 final Location location = new Location(Latitude.degrees(latlon.lat()),
                         Longitude.degrees(latlon.lon()));
                 final TreeSet<SnappedEntity> itemsNearClick = new TreeSet<>();
@@ -678,7 +678,7 @@ public class AtlasReaderDialog extends ToggleDialog implements LayerChangeListen
                     final BoundingXYVisitor visitor = new BoundingXYVisitor();
                     visitor.computeBoundingBox(
                             AtlasReaderDialog.this.layer.getData().allPrimitives());
-                    Main.map.mapView.zoomTo(visitor.getBounds());
+                    MainApplication.getMap().mapView.zoomTo(visitor.getBounds());
 
                     // highlight all search results, unless "all" is the mode
                     if (!"All".equals(searchOptions.getSelectedItem().toString()))
@@ -699,16 +699,16 @@ public class AtlasReaderDialog extends ToggleDialog implements LayerChangeListen
                             toBeSelected.add(result.getPrimitiveId());
                         }
                         AtlasReaderDialog.this.layer.getData().setSelected(toBeSelected);
-                        Main.map.mapView.revalidate();
-                        Main.map.mapView.repaint();
+                        MainApplication.getMap().mapView.revalidate();
+                        MainApplication.getMap().mapView.repaint();
                         AtlasReaderDialog.this.previousResults = results;
                     }
 
                     // recreate list listeners with new list index (results of search)
                     createListListeners(searcher.getIndexToIdentifier());
-                    for (final MouseListener mouseListener : Main.map.mapView.getMouseListeners())
+                    for (final MouseListener mouseListener : MainApplication.getMap().mapView.getMouseListeners())
                     {
-                        Main.map.mapView.removeMouseListener(mouseListener);
+                        MainApplication.getMap().mapView.removeMouseListener(mouseListener);
                     }
                     createMapListener(searcher.getIndexToIdentifier());
                 }
@@ -756,7 +756,7 @@ public class AtlasReaderDialog extends ToggleDialog implements LayerChangeListen
                 // show entire Atlas
                 final BoundingXYVisitor visitor = new BoundingXYVisitor();
                 visitor.computeBoundingBox(AtlasReaderDialog.this.layer.getData().allPrimitives());
-                Main.map.mapView.zoomTo(visitor.getBounds());
+                MainApplication.getMap().mapView.zoomTo(visitor.getBounds());
             }
         };
         showAll.addActionListener(showEntireAtlas);
@@ -780,7 +780,7 @@ public class AtlasReaderDialog extends ToggleDialog implements LayerChangeListen
         }
         if (visitor.getBounds() != null)
         {
-            Main.map.mapView.zoomTo(visitor.getBounds());
+            MainApplication.getMap().mapView.zoomTo(visitor.getBounds());
         }
     }
 }

--- a/src/main/java/org/openstreetmap/atlas/AtlasReaderDialog.java
+++ b/src/main/java/org/openstreetmap/atlas/AtlasReaderDialog.java
@@ -354,7 +354,8 @@ public class AtlasReaderDialog extends ToggleDialog implements LayerChangeListen
 
                     // recreate list listeners with new list index (results of search)
                     createListListeners(searcher.getIndexToIdentifier());
-                    for (final MouseListener mouseListener : MainApplication.getMap().mapView.getMouseListeners())
+                    for (final MouseListener mouseListener : MainApplication.getMap().mapView
+                            .getMouseListeners())
                     {
                         MainApplication.getMap().mapView.removeMouseListener(mouseListener);
                     }
@@ -469,7 +470,8 @@ public class AtlasReaderDialog extends ToggleDialog implements LayerChangeListen
                     previous.setHighlighted(false);
                 }
                 listClick = false;
-                final LatLon latlon = MainApplication.getMap().mapView.getLatLon(event.getX(), event.getY());
+                final LatLon latlon = MainApplication.getMap().mapView.getLatLon(event.getX(),
+                        event.getY());
                 final Location location = new Location(Latitude.degrees(latlon.lat()),
                         Longitude.degrees(latlon.lon()));
                 final TreeSet<SnappedEntity> itemsNearClick = new TreeSet<>();
@@ -706,7 +708,8 @@ public class AtlasReaderDialog extends ToggleDialog implements LayerChangeListen
 
                     // recreate list listeners with new list index (results of search)
                     createListListeners(searcher.getIndexToIdentifier());
-                    for (final MouseListener mouseListener : MainApplication.getMap().mapView.getMouseListeners())
+                    for (final MouseListener mouseListener : MainApplication.getMap().mapView
+                            .getMouseListeners())
                     {
                         MainApplication.getMap().mapView.removeMouseListener(mouseListener);
                     }


### PR DESCRIPTION
Fixes #3.
Two APIs still used have been removed in revision [13173](https://josm.openstreetmap.de/changeset/13173/josm).
No need to increase the min version, the replacements APIs have been introduced before ([12630](https://josm.openstreetmap.de/changeset/12630/josm)/[12636](https://josm.openstreetmap.de/changeset/12636/josm))