### PR TITLE
Use locked dataset to reuse standard JOSM UI

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -20,14 +20,14 @@ group = 'org.openstreetmap.atlas'
 
 archivesBaseName = 'josm-atlas'
 josm { // see https://floscher.github.io/gradle-josm-plugin/kdoc/v0.3.2/gradle-josm-plugin/org.openstreetmap.josm.gradle.plugin.config/-josm-plugin-extension
-  josmCompileVersion '13367'
+  josmCompileVersion '13446'
   manifest { // see https://floscher.github.io/gradle-josm-plugin/kdoc/v0.3.2/gradle-josm-plugin/org.openstreetmap.josm.gradle.plugin.config/-josm-manifest
     author = 'James Gage'
     canLoadAtRuntime = true
     description = 'Allows you to view an Atlas file as a layer.'
     iconPath = 'images/dialogs/world-3.png'
     mainClass = 'org.openstreetmap.atlas.AtlasReader'
-    minJosmVersion = '12712'
+    minJosmVersion = '13440'
     website = new URL('https://github.com/osmlab/josm-atlas')
   }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -20,14 +20,14 @@ group = 'org.openstreetmap.atlas'
 
 archivesBaseName = 'josm-atlas'
 josm { // see https://floscher.github.io/gradle-josm-plugin/kdoc/v0.3.2/gradle-josm-plugin/org.openstreetmap.josm.gradle.plugin.config/-josm-plugin-extension
-  josmCompileVersion '13446'
+  josmCompileVersion '13500'
   manifest { // see https://floscher.github.io/gradle-josm-plugin/kdoc/v0.3.2/gradle-josm-plugin/org.openstreetmap.josm.gradle.plugin.config/-josm-manifest
     author = 'James Gage'
     canLoadAtRuntime = true
     description = 'Allows you to view an Atlas file as a layer.'
     iconPath = 'images/dialogs/world-3.png'
     mainClass = 'org.openstreetmap.atlas.AtlasReader'
-    minJosmVersion = '13440'
+    minJosmVersion = '13457'
     website = new URL('https://github.com/osmlab/josm-atlas')
   }
 }

--- a/src/main/java/org/openstreetmap/atlas/AtlasFileImporter.java
+++ b/src/main/java/org/openstreetmap/atlas/AtlasFileImporter.java
@@ -23,6 +23,7 @@ import org.openstreetmap.josm.gui.io.importexport.FileImporter;
 import org.openstreetmap.josm.gui.progress.ProgressMonitor;
 import org.openstreetmap.josm.gui.util.GuiHelper;
 import org.openstreetmap.josm.io.IllegalDataException;
+import org.openstreetmap.josm.tools.Logging;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +60,7 @@ public class AtlasFileImporter extends FileImporter
         }
         catch (final Exception e)
         {
-            e.printStackTrace();
+            Logging.error(e);
             JOptionPane.showMessageDialog(null, e.toString(), "Corrupt Atlas File",
                     JOptionPane.ERROR_MESSAGE);
         }

--- a/src/main/java/org/openstreetmap/atlas/AtlasReaderDialog.java
+++ b/src/main/java/org/openstreetmap/atlas/AtlasReaderDialog.java
@@ -11,8 +11,6 @@ import java.nio.charset.Charset;
 import java.nio.charset.CharsetEncoder;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Iterator;
-import java.util.Set;
 import java.util.TreeSet;
 
 import javax.swing.AbstractAction;
@@ -25,7 +23,6 @@ import javax.swing.JList;
 import javax.swing.JOptionPane;
 import javax.swing.JPanel;
 import javax.swing.JScrollPane;
-import javax.swing.JTable;
 import javax.swing.JTextField;
 import javax.swing.KeyStroke;
 
@@ -59,6 +56,7 @@ import org.openstreetmap.josm.gui.layer.LayerManager.LayerAddEvent;
 import org.openstreetmap.josm.gui.layer.LayerManager.LayerChangeListener;
 import org.openstreetmap.josm.gui.layer.LayerManager.LayerOrderChangeEvent;
 import org.openstreetmap.josm.gui.layer.LayerManager.LayerRemoveEvent;
+import org.openstreetmap.josm.tools.Logging;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -213,7 +211,6 @@ public class AtlasReaderDialog extends ToggleDialog implements LayerChangeListen
 
     private final AtlasReaderLayer layer;
     private final JPanel panel;
-    private JTable tagBox = null;
     private JList<PrintablePrimitive> list;
     private DefaultListModel<PrintablePrimitive> listAll;
     private JScrollPane listPane;
@@ -387,8 +384,6 @@ public class AtlasReaderDialog extends ToggleDialog implements LayerChangeListen
                 if (identifier != null)
                 {
                     zoomTo(AtlasReaderDialog.this.layer.getData().getPrimitiveById(identifier));
-                    createTagBox(
-                            AtlasReaderDialog.this.layer.getData().getPrimitiveById(identifier));
                 }
             }
         });
@@ -400,7 +395,6 @@ public class AtlasReaderDialog extends ToggleDialog implements LayerChangeListen
                 final PrimitiveId identifier = indexToIdentifier.get(index);
                 this.layer.getData().setSelected(identifier);
                 zoomTo(this.layer.getData().getPrimitiveById(identifier));
-                createTagBox(this.layer.getData().getPrimitiveById(identifier));
             }
         });
 
@@ -422,7 +416,6 @@ public class AtlasReaderDialog extends ToggleDialog implements LayerChangeListen
                         .get(AtlasReaderDialog.this.selectedIndex);
                 AtlasReaderDialog.this.layer.getData().setSelected(identifier);
                 zoomTo(AtlasReaderDialog.this.layer.getData().getPrimitiveById(identifier));
-                createTagBox(AtlasReaderDialog.this.layer.getData().getPrimitiveById(identifier));
                 AtlasReaderDialog.this.list
                         .ensureIndexIsVisible(AtlasReaderDialog.this.selectedIndex);
             }
@@ -443,7 +436,6 @@ public class AtlasReaderDialog extends ToggleDialog implements LayerChangeListen
                         .get(AtlasReaderDialog.this.selectedIndex);
                 AtlasReaderDialog.this.layer.getData().setSelected(identifier);
                 zoomTo(AtlasReaderDialog.this.layer.getData().getPrimitiveById(identifier));
-                createTagBox(AtlasReaderDialog.this.layer.getData().getPrimitiveById(identifier));
                 AtlasReaderDialog.this.list
                         .ensureIndexIsVisible(AtlasReaderDialog.this.selectedIndex);
             }
@@ -526,40 +518,12 @@ public class AtlasReaderDialog extends ToggleDialog implements LayerChangeListen
                     }
                     catch (final Exception e)
                     {
-                        e.printStackTrace();
+                        Logging.error(e);
                     }
                     previous = selected;
-                    createTagBox(selected);
                 }
             }
         });
-    }
-
-    /*
-     * Converts tagMap to 2d array and creates/updates the Tag Box.
-     */
-    private void createTagBox(final OsmPrimitive selected)
-    {
-        if (this.tagBox != null)
-        {
-            this.panel.remove(this.tagBox);
-        }
-        final Set<String> keys = selected.getKeys().keySet();
-        final Iterator<String> keyIterator = keys.iterator();
-        final Iterator<String> valuesIterator = selected.getKeys().values().iterator();
-        final String[] columnNames = { "Key", "Value" };
-        final String[][] data = new String[keys.size() + 1][2];
-        data[0][0] = "atlas_identifier";
-        data[0][1] = String.valueOf(selected.getId());
-        for (int i = 1; i < keys.size() + 1; i++)
-        {
-            data[i][0] = keyIterator.next();
-            data[i][1] = valuesIterator.next();
-        }
-        this.tagBox = new JTable(data, columnNames);
-        this.panel.add(this.tagBox, BorderLayout.SOUTH);
-        this.tagBox.revalidate();
-        this.tagBox.repaint();
     }
 
     private void historyButtonInit(final JButton historyButton)

--- a/src/main/java/org/openstreetmap/atlas/AtlasReaderLayer.java
+++ b/src/main/java/org/openstreetmap/atlas/AtlasReaderLayer.java
@@ -1,40 +1,40 @@
 package org.openstreetmap.atlas;
 
-import java.awt.Graphics2D;
+import static org.openstreetmap.josm.tools.I18n.tr;
 
 import javax.swing.Action;
 import javax.swing.Icon;
 
 import org.openstreetmap.atlas.geography.atlas.Atlas;
-import org.openstreetmap.josm.Main;
 import org.openstreetmap.josm.data.Bounds;
 import org.openstreetmap.josm.data.osm.DataSet;
 import org.openstreetmap.josm.data.osm.visitor.BoundingXYVisitor;
-import org.openstreetmap.josm.data.osm.visitor.paint.MapRendererFactory;
-import org.openstreetmap.josm.data.osm.visitor.paint.Rendering;
-import org.openstreetmap.josm.gui.MapView;
-import org.openstreetmap.josm.gui.layer.AbstractModifiableLayer;
 import org.openstreetmap.josm.gui.layer.Layer;
+import org.openstreetmap.josm.gui.layer.OsmDataLayer;
 import org.openstreetmap.josm.tools.ImageProvider;
+import org.openstreetmap.josm.tools.Logging;
 
 /**
  * @author jgage
  */
-public class AtlasReaderLayer extends AbstractModifiableLayer
+public class AtlasReaderLayer extends OsmDataLayer
 {
-    private static String LAYER_NAME = "Atlas Layer";
+    private static final String LAYER_NAME = tr("Atlas Layer");
 
     private Atlas atlas;
-    private final DataSet dataSet;
     private final Bounds bounds;
 
     public AtlasReaderLayer(final String info, final DataSet data, final Atlas atlas,
             final Bounds bounds)
     {
-        super(info);
-        this.dataSet = data;
+        super(data, info, null);
         this.atlas = atlas;
         this.bounds = bounds;
+        // Make sure dataset is read-only
+        if (!data.isReadOnly())
+        {
+            data.setReadOnly();
+        }
     }
 
     @Override
@@ -50,13 +50,13 @@ public class AtlasReaderLayer extends AbstractModifiableLayer
 
     public DataSet getData()
     {
-        return this.dataSet;
+        return this.data;
     }
 
     @Override
     public Icon getIcon()
     {
-        return ImageProvider.get("dialogs", "world");
+        return new ImageProvider("dialogs/world").setSize(ImageProvider.ImageSizes.LAYER).get();
     }
 
     @Override
@@ -78,46 +78,9 @@ public class AtlasReaderLayer extends AbstractModifiableLayer
     }
 
     @Override
-    public boolean isMergable(final Layer arg0)
+    public boolean isMergable(final Layer other)
     {
         return false;
-    }
-
-    /**
-     * Atlas should be treated as immutable.
-     *
-     * @return Always false
-     */
-    @Override
-    public final boolean isModified()
-    {
-        return false;
-    }
-
-    /**
-     * We should not be able to merge layers.
-     *
-     * @param layer
-     *            The layer parameter is ignored
-     */
-    @Override
-    public void mergeFrom(final Layer layer)
-    {
-    }
-
-    /**
-     * Paints the dataSet comprised of the OSM equivalents of atlas objects.
-     */
-    @Override
-    public void paint(final Graphics2D graphics, final MapView mapView, final Bounds bounds)
-    {
-        final boolean active = mapView.getLayerManager().getActiveLayer() == this;
-        final boolean inactive = !active && Main.pref.getBoolean("draw.data.inactive_color", true);
-        final boolean virtual = !inactive && mapView.isVirtualNodesEnabled();
-        Main.pref.getBoolean("draw.data.inactive_color", false);
-        final Rendering painter = MapRendererFactory.getInstance().createActiveRenderer(graphics,
-                mapView, inactive);
-        painter.render(this.dataSet, virtual, bounds);
     }
 
     @Override

--- a/src/main/java/org/openstreetmap/atlas/AtlasReaderLayer.java
+++ b/src/main/java/org/openstreetmap/atlas/AtlasReaderLayer.java
@@ -12,7 +12,6 @@ import org.openstreetmap.josm.data.osm.visitor.BoundingXYVisitor;
 import org.openstreetmap.josm.gui.layer.Layer;
 import org.openstreetmap.josm.gui.layer.OsmDataLayer;
 import org.openstreetmap.josm.tools.ImageProvider;
-import org.openstreetmap.josm.tools.Logging;
 
 /**
  * @author jgage
@@ -31,9 +30,9 @@ public class AtlasReaderLayer extends OsmDataLayer
         this.atlas = atlas;
         this.bounds = bounds;
         // Make sure dataset is read-only
-        if (!data.isReadOnly())
+        if (!data.isLocked())
         {
-            data.setReadOnly();
+            data.lock();
         }
     }
 

--- a/src/main/java/org/openstreetmap/atlas/AtlasSearch.java
+++ b/src/main/java/org/openstreetmap/atlas/AtlasSearch.java
@@ -18,6 +18,7 @@ import org.openstreetmap.josm.data.osm.PrimitiveId;
 import org.openstreetmap.josm.data.osm.Relation;
 import org.openstreetmap.josm.data.osm.TagMap;
 import org.openstreetmap.josm.data.osm.Way;
+import org.openstreetmap.josm.tools.Logging;
 
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
@@ -30,7 +31,6 @@ public class AtlasSearch
     /**
      * @author jgage
      */
-
     public enum SearchType
     {
         OSM_IDENTIFIER("OSM ID"),
@@ -102,7 +102,7 @@ public class AtlasSearch
                     }
                     catch (final Exception e)
                     {
-                        e.printStackTrace();
+                        Logging.error(e);
                     }
                 }
                 break;


### PR DESCRIPTION
This PR makes `AtlasReaderLayer` extends `OsmDataLayer` in order to benefit from standard JOSM HMI (tags dialog, filters, search, presets, etc.: the list is long).

This relies on the new "locked layer" feature available in JOSM 13500. The underlying dataset is always locked so it cannot be modified in any way.

As an immediate consequence the "tag box" is removed as it is redundant with JOSM tag dialog.