### PR TITLE
Decrypt the secret signing key on all branches (except PRs)

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -10,7 +10,10 @@ else
 	echo "Not a manual release"
 fi
 
-if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ];
+if [ -z "$encrypted_7407e5ec1bc3_key" ] || [ -z "$encrypted_7407e5ec1bc3_iv" ] || [ -z "$ENCRYPTED_GPG_KEY_LOCATION" ] || [ -z "$GPG_KEY_LOCATION" ];
 then
+    echo "The secret signing key is not being decrypted (the necessary environment variables are not set)."
+else
+    echo "Decrypting the secret signing key…"
     openssl aes-256-cbc -K $encrypted_7407e5ec1bc3_key -iv $encrypted_7407e5ec1bc3_iv -in $ENCRYPTED_GPG_KEY_LOCATION -out $GPG_KEY_LOCATION -d
 fi


### PR DESCRIPTION
This should fix the currently failing build. As discussed in https://github.com/osmlab/josm-atlas/pull/13/files#r169728452 , I modified the Gradle build to always sign the build artifacts. But I overlooked that the secret keyring only gets decrypted for the master branch.

Starting with this commit the decryption only depends on the availability of the environment variables used for decryption (`$encrypted_7407e5ec1bc3_key`, `$encrypted_7407e5ec1bc3_iv`, …).
These variables are not available for forks and pull requests. As soon as they'd be available to a malicious party, the encrypted key would otherwise be compromised.
So it should be safe to not check the current branch but these environment variables instead.